### PR TITLE
Support to multiple ListData assets

### DIFF
--- a/Assets/BrokenVector/FavoritesList/Editor/Constants.cs
+++ b/Assets/BrokenVector/FavoritesList/Editor/Constants.cs
@@ -21,5 +21,8 @@ namespace BrokenVector.FavoritesList
         // Editor Pref Paths
         public const string DEBUG_PREF = "Debug";                               // has to match FavoritesListReference.DEBUG_PREF (with AssetPrefs)
 
+        // File Creation
+        public const string DEFAULT_FILENAME = "NewFavoritesList";
+        public const string CREATE_MENU_OPTION = "Favorites List/List";
     }
 }

--- a/Assets/BrokenVector/FavoritesList/Editor/ListData.asset.meta
+++ b/Assets/BrokenVector/FavoritesList/Editor/ListData.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fc306e5a9238247408471239d17ae50f
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/BrokenVector/FavoritesList/Editor/ListData.cs
+++ b/Assets/BrokenVector/FavoritesList/Editor/ListData.cs
@@ -1,15 +1,18 @@
 using UnityEngine;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 
 namespace BrokenVector.FavoritesList
 {
+    [CreateAssetMenu(fileName = Constants.DEFAULT_FILENAME, menuName = Constants.CREATE_MENU_OPTION, order = 1)]
     [System.Serializable]
     public class ListData : ScriptableObject
     {
-
         public List<ObjectReference> References = new List<ObjectReference>();
+
+        private static List<ListData> listData = new List<ListData>();
 
         public void AddReference(ObjectReference obj)
         {
@@ -32,27 +35,29 @@ namespace BrokenVector.FavoritesList
             AssetDatabase.SaveAssets();
         }
 
-        public static ListData LoadList()
+        public static ListData LoadList(string path)
         {
-            ListData list = AssetDatabase.LoadAssetAtPath(GetAssetLocation(), typeof(ListData)) as ListData;
-            if (list != null)
-                return list;
-
-            list = CreateInstance<ListData>();
-            AssetDatabase.CreateAsset(list, GetAssetLocation());
-            AssetDatabase.SaveAssets();
-
-            return list;
+            return AssetDatabase.LoadAssetAtPath(path, typeof(ListData)) as ListData;
         }
 
-        private static string GetAssetLocation()
+        public static List<string> GetAssetsLocation()
         {
-            var guid = AssetDatabase.FindAssets("ListData")[0];
-            var path = AssetDatabase.GUIDToAssetPath(guid);
-            if (path.EndsWith(".cs"))
-                return path.Remove(path.Length - 2) + "asset"; // .cs to .asset
-            else
-                return path;
+            var guid = AssetDatabase.FindAssets("t:" + typeof(ListData).Name);
+            var pathList = new List<string>();
+
+            for (int i = guid.Length - 1; i >= 0; i--)
+            {
+                pathList.Add(AssetDatabase.GUIDToAssetPath(guid[i]));
+            }
+
+            return pathList;
+        }
+
+        public static void CreateNewListData()
+        {
+            ListData list = CreateInstance<ListData>();
+            AssetDatabase.CreateAsset(list, "Assets/" + Constants.DEFAULT_FILENAME + ".asset");
+            AssetDatabase.SaveAssets();
         }
 
     }


### PR DESCRIPTION
Hey @michidk, I've just finished implement the support to multiple config files, it seems to work just fine. My biggest concern here is compatibility with older Unity versions since I used Unity 2020.1 to develop and tested on 2019 LTS as well.

I ended up creating a context menu to create instances of the ScriptableObject ListData throught the menu "Create -> Favorites List -> List", this way, instead of automatically creating a new asset when there are none, I created a button so a user can name it.

There is also a support for identifying files in different folders but with the same name.

Thanks for allowing modification on the source code and I hope my commit can be useful.